### PR TITLE
feat/remove admin api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
@@ -97,9 +97,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
+checksum = "18e746cb4cea9ab4cda8cb117717b16c21116004f51efd78968ee0f1ffcf2602"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6967ca1ed656766e471bc323da42fb0db320ca5e1418b408650e98e4757b3d2"
+checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -137,15 +137,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
+checksum = "659c33e85c4a9f8bb1b9a2400f4f3d0dd52fbc4bd3650e08d22df1e17d5d92ee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
+ "alloy-tx-macros",
  "auto_impl",
  "c-kzg",
  "derive_more",
@@ -161,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+checksum = "d48fdc146414932cec2114f749f5f65a8960ee7547b1638a97bb0d04160d09e4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -175,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
+checksum = "c711bfed1579611565ab831166c7bbaf123baea785ea945f02ed3620950f6fe1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -192,6 +193,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
+ "serde_json",
  "thiserror 2.0.12",
 ]
 
@@ -265,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
+checksum = "8390cb5c872d53560635dabc02d616c1bb626dd0f7d6893f8725edb822573fed"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -306,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
+checksum = "a18ce1538291d8409d4a7d826176d461a6f9eb28632d7185f801bda43a138260"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
+checksum = "977d2492ce210e34baf7b36afaacea272c96fbe6774c47e23f97d14033c0e94f"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -345,12 +347,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
+checksum = "0b91481d12dcd964f4a838271d6abffac2d4082695fc3f73a15429166ea1692d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "http",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -359,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
+checksum = "c8b245fa9d76cc9fc58cf78844f2d4e481333449ba679b2044f09b983fc96f85"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -385,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
+checksum = "7cecb975fc2f2e1eb09c513428c34e0d8c13e28b5ff1dbdf68e0f64a1a92c5f3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -398,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec6d2e7743d2bcb3e7dfc9cb7a7322bc0f808fddd48f4aab5d974260f2ae0cf"
+checksum = "f4131fe12c27e13a99d79bc8e02f9ce4f23f98a6f2e90458fe09992e99e46a9a"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -436,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-op-hardforks"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ddfbb5cc9f614efa5d56e0d7226214bb67b29271d44b6ddfcbbe25eb0ff898b"
+checksum = "08b147547aff595aa3d4c2fc2c8146263e18d3372909def423619ed631ecbcfa"
 dependencies = [
  "alloy-hardforks",
  "auto_impl",
@@ -457,7 +460,7 @@ dependencies = [
  "derive_more",
  "foldhash",
  "getrandom 0.3.3",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "itoa",
  "k256",
@@ -474,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
+checksum = "ecac2cbea1cb3da53b4e68a078e57f9da8d12d86e2017db1240df222e2498397"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -507,6 +510,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
+ "http",
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
@@ -522,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
+checksum = "db1d3c2316590910ba697485aa75cdafef89735010d338d197f8af5baa79df92"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -560,14 +564,14 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
+checksum = "e0bed8157038003c702dd1861a6b72d4b1a8f46aeffad35e81580223642170fa"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -593,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
+checksum = "82fed036edc62cd79476fe0340277a1c47b07c173f6ac0244f24193e1183b8e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -610,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebdc864f573645c5288370c208912b85b5cacc8025b700c50c2b74d06ab9830"
+checksum = "b3ca809955fc14d8bd681470613295eacdc6e62515a13aa3871ab6f7decfd740"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -622,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+checksum = "9f2e3dc925ec6722524f8d7412b9a6845a3350c7037f8a37892ada00c9018125"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -634,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+checksum = "caf6702dd7eb929068ab075869679e745d68c4eb611c5a0cf72617688b85b5f4"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -645,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241aba7808bddc3ad1c6228e296a831f326f89118b1017012090709782a13334"
+checksum = "497cf019e28c3538d83b3791b780047792a453c693fcca9ded49d9c81550663e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -663,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+checksum = "0e982f72ff47c0f754cb6aa579e456220d768e1ec07675e66cfce970dad70292"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -673,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
+checksum = "505224e162e239980c6df7632c99f0bc5abbcf630017502810979e9e01f3c86e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -694,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
+checksum = "20ff509ca40537042b7cc9bede6b415ef807c9c5c48024e9fe10b8c8ad0757ef"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -715,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bd1c5d7b9f3f1caeeaa1c082aa28ba7ce2d67127b12b2a9b462712c8f6e1c5"
+checksum = "6bfb385704970757f21cfc6f79adc22c743523242d032c9ca42d70773a0f7b7c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -730,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
+checksum = "51dc49d5865f2227c810a416c8d14141db7716a0174bfa6cff1c1a984b678b5e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -744,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+checksum = "c962ec5193084873353ad7a65568056b4e704203302e6ba81374e95a22deba4d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -756,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
+checksum = "f9873512b1e99505f4a65e1d3a3105cb689f112f8e3cab3c632b20a97a46adae"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -767,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
+checksum = "c2d4d95d8431a11e0daee724c3b7635dc8e9d3d60d0b803023a8125c74a77899"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -782,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
+checksum = "cb03eca937485b258d8e791d143e95b50dbfae0e18f92e1b1271c38959cd00fb"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -807,7 +811,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -824,7 +828,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -843,7 +847,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.101",
+ "syn 2.0.103",
  "syn-solidity",
 ]
 
@@ -871,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
+checksum = "468a871d7ea52e31ef3abf5ccde612cb3723794f484d26dca6a04a3a776db739"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -894,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
+checksum = "6e969c254b189f7da95f07bab53673dd418f8595abfe3397b2cf8d7ba7955487"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -909,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
+checksum = "cb134aaa80c2e1e03eebc101e7c513f08a529726738506d8c306ec9f3c9a7f3b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -929,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
+checksum = "e57f13346af9441cafa99d5b80d95c2480870dd18bd274464f7131df01ad692a"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -959,6 +963,19 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d642ba58c32547ad9742c613f9849a2aedc47914b02948224326e4cb62b91040"
+dependencies = [
+ "alloy-primitives",
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1043,7 +1060,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1083,7 +1100,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -1176,7 +1193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1214,7 +1231,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1229,7 +1246,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1303,7 +1320,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1359,9 +1376,9 @@ checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
 name = "async-compression"
-version = "0.4.23"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
 dependencies = [
  "brotli",
  "flate2",
@@ -1392,7 +1409,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1403,7 +1420,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1441,14 +1458,14 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -1519,7 +1536,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1623,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -1674,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1692,9 +1709,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -1799,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -1847,9 +1864,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1857,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1869,21 +1886,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
@@ -1958,7 +1975,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "contender_bundle_provider"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "serde",
@@ -1968,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "contender_core"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1990,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "contender_engine_provider"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2015,7 +2032,7 @@ dependencies = [
 [[package]]
 name = "contender_report"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "chrono",
@@ -2034,7 +2051,7 @@ dependencies = [
 [[package]]
 name = "contender_sqlite"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2047,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "contender_testfile"
 version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2257,7 +2274,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2281,7 +2298,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2292,7 +2309,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2345,7 +2362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2398,13 +2415,13 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2425,7 +2442,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2435,7 +2452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2456,7 +2473,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "unicode-xid",
 ]
 
@@ -2515,7 +2532,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2570,7 +2587,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2640,7 +2657,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2701,7 +2718,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2721,7 +2738,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2797,7 +2814,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2902,9 +2919,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3017,7 +3034,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3077,7 +3094,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows 0.61.1",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3101,7 +3118,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3269,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3306,9 +3323,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3392,15 +3409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3494,9 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.6"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
@@ -3715,7 +3723,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3761,7 +3769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -4023,7 +4031,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4168,9 +4176,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libgit2-sys"
@@ -4191,7 +4199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -4379,7 +4387,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -4388,7 +4396,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -4399,9 +4407,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "2c592ad9fbc1b7838633b3ae55ce69b17d01150c72fcef229fbb819d39ee51ee"
 
 [[package]]
 name = "mach2"
@@ -4420,7 +4428,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4434,9 +4442,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -4466,7 +4474,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4507,7 +4515,7 @@ checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.15.3",
+ "hashbrown 0.15.4",
  "metrics",
  "quanta",
  "rand 0.9.1",
@@ -4554,9 +4562,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -4569,7 +4577,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -4859,7 +4867,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5076,7 +5084,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5157,7 +5165,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5207,9 +5215,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -5218,9 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -5228,24 +5236,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2 0.10.9",
 ]
@@ -5291,7 +5298,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5320,7 +5327,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5365,9 +5372,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
@@ -5451,7 +5458,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5505,17 +5512,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -5556,15 +5563,15 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -5650,9 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -5746,11 +5753,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5799,9 +5806,9 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -5826,6 +5833,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5874,9 +5901,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
@@ -5890,12 +5917,9 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6038,7 +6062,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -8299,9 +8323,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "4.0.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91f9b90b3bab18942252de2d970ee8559794c49ca7452b2cc1774456040f8fb"
+checksum = "942fe4724cf552fd28db6b0a2ca5b79e884d40dd8288a4027ed1e9090e0c6f49"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -8460,9 +8484,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "19.1.0"
+version = "19.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ea2ea0134568ee1e14281ce52f60e2710d42be316888d464c53e37ff184fd8"
+checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -8635,9 +8659,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -8706,9 +8730,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -8828,6 +8852,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -8981,7 +9017,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -8999,9 +9035,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -9020,15 +9056,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9038,14 +9075,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9197,18 +9234,15 @@ checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
@@ -9292,7 +9326,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9314,9 +9348,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9332,7 +9366,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9352,7 +9386,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9419,7 +9453,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9430,17 +9464,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -9545,7 +9578,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9613,9 +9646,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -9625,18 +9658,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -9648,9 +9681,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -9741,20 +9774,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9868,7 +9901,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10121,9 +10154,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -10156,7 +10189,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -10191,7 +10224,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10207,9 +10240,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+checksum = "d8d49b5d6c64e8558d9b1b065014426f35c18de636895d24893dbbd329743446"
 dependencies = [
  "futures",
  "js-sys",
@@ -10241,12 +10274,11 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
+checksum = "aaf4f3c0ba838e82b4e5ccc4157003fb8c324ee24c058470ffb82820becbde98"
 dependencies = [
  "core-foundation 0.10.1",
- "home",
  "jni",
  "log",
  "ndk-context",
@@ -10351,9 +10383,9 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
@@ -10428,7 +10460,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10439,7 +10471,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10450,7 +10482,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10461,7 +10493,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10472,7 +10504,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10483,14 +10515,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-numerics"
@@ -10585,6 +10617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10632,9 +10673,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -10837,9 +10878,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -10871,9 +10912,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "ws_stream_wasm"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
 dependencies = [
  "async_io_stream",
  "futures",
@@ -10882,7 +10923,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -10923,28 +10964,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10964,7 +11005,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -10985,7 +11026,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -11018,7 +11059,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,12 +1886,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,8 +1957,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.1.6"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "serde",
@@ -1973,8 +1967,8 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.1.6"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "async-trait",
@@ -1995,8 +1989,8 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.1.6"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2020,8 +2014,8 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.1.0"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "chrono",
@@ -2029,7 +2023,6 @@ dependencies = [
  "csv",
  "futures",
  "handlebars",
- "plotters",
  "regex",
  "serde",
  "serde_json",
@@ -2040,8 +2033,8 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.1.6"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2053,8 +2046,8 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.1.6"
-source = "git+https://github.com/flashbots/contender#c84463c297db06e459bffb264c7b78a9f66c7b56"
+version = "0.2.1"
+source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#bcc186d77db7d85ae1f69e360c0cd573982c676a"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2098,42 +2091,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types",
- "foreign-types 0.5.0",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-text"
-version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
-dependencies = [
- "core-foundation 0.9.4",
- "core-graphics",
- "foreign-types 0.5.0",
- "libc",
-]
 
 [[package]]
 name = "core2"
@@ -2617,15 +2574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "doctest-file"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,18 +2584,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "dwrote"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe1f192fcce01590bd8d839aca53ce0d11d803bf291b2a6c4ad925a8f0024be"
-dependencies = [
- "lazy_static",
- "libc",
- "winapi",
- "wio",
-]
 
 [[package]]
 name = "dyn-clone"
@@ -2915,15 +2851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "fdlimit"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,12 +2911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,58 +2923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "font-kit"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
-dependencies = [
- "bitflags 2.9.1",
- "byteorder",
- "core-foundation 0.9.4",
- "core-graphics",
- "core-text",
- "dirs",
- "dwrote",
- "float-ord",
- "freetype-sys",
- "lazy_static",
- "libc",
- "log",
- "pathfinder_geometry",
- "pathfinder_simd",
- "walkdir",
- "winapi",
- "yeslogic-fontconfig-sys",
-]
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.1",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -3063,29 +2938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "freetype-sys"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -3269,16 +3127,6 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
-]
-
-[[package]]
-name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -3851,20 +3699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4074,12 +3908,6 @@ dependencies = [
  "getrandom 0.3.3",
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -4731,7 +4559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -5234,7 +5061,7 @@ checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
- "foreign-types 0.3.2",
+ "foreign-types",
  "libc",
  "once_cell",
  "openssl-macros",
@@ -5361,25 +5188,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pathfinder_geometry"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
-dependencies = [
- "log",
- "pathfinder_simd",
-]
-
-[[package]]
-name = "pathfinder_simd"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
-dependencies = [
- "rustc_version 0.4.1",
-]
 
 [[package]]
 name = "pem"
@@ -5542,65 +5350,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "chrono",
- "font-kit",
- "image",
- "lazy_static",
- "num-traits",
- "pathfinder_geometry",
- "plotters-backend",
- "plotters-bitmap",
- "plotters-svg",
- "ttf-parser",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-bitmap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
-dependencies = [
- "gif",
- "image",
- "plotters-backend",
-]
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "polyval"
@@ -9408,12 +9157,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10141,12 +9884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10554,12 +10291,6 @@ checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
 name = "widestring"
@@ -11124,15 +10855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wio"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11180,17 +10902,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yeslogic-fontconfig-sys"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
-dependencies = [
- "dlib",
- "once_cell",
- "pkg-config",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,8 +1974,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "serde",
@@ -1984,8 +1984,8 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2006,8 +2006,8 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2031,8 +2031,8 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "chrono",
@@ -2050,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2063,8 +2063,8 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.2.1"
-source = "git+https://github.com/flashbots/contender?branch=feat%2Fagent-api#5ded7e20225938dca659d4802f2b99de9c86ede5"
+version = "0.2.2"
+source = "git+https://github.com/flashbots/contender#64efd28d703241c69f8dfc01dc8a7b7c1d29f5d3"
 dependencies = [
  "alloy",
  "contender_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-contender_core = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
-contender_report = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
-contender_sqlite = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
-contender_testfile = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
+contender_core = { git = "https://github.com/flashbots/contender", version = "0.2.2" }
+contender_report = { git = "https://github.com/flashbots/contender", version = "0.2.2" }
+contender_sqlite = { git = "https://github.com/flashbots/contender", version = "0.2.2" }
+contender_testfile = { git = "https://github.com/flashbots/contender", version = "0.2.2" }
 # contender_core.path = "../contender/crates/core"
 # contender_report.path = "../contender/crates/report"
 # contender_sqlite.path = "../contender/crates/sqlite_db"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-contender_core = { git = "https://github.com/flashbots/contender" }
-contender_report = { git = "https://github.com/flashbots/contender" }
-contender_sqlite = { git = "https://github.com/flashbots/contender" }
-contender_testfile = { git = "https://github.com/flashbots/contender" }
+contender_core = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
+contender_report = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
+contender_sqlite = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
+contender_testfile = { git = "https://github.com/flashbots/contender", branch = "feat/agent-api" }
 # contender_core.path = "../contender/crates/core"
 # contender_report.path = "../contender/crates/report"
 # contender_sqlite.path = "../contender/crates/sqlite_db"
 # contender_testfile.path = "../contender/crates/testfile"
+
 
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.40.0", features = ['rt-multi-thread'] }

--- a/src/admin_api.rs
+++ b/src/admin_api.rs
@@ -1,0 +1,265 @@
+use contender_core::alloy::{
+    primitives::{Address, Bytes, FixedBytes, U256, keccak256},
+    rpc::types::{AccessList, AccessListItem, Log},
+    sol,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::contracts;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentifierWithPayload {
+    pub origin: Address,
+    pub block_number: u64,
+    pub log_index: u64,
+    pub timestamp: u64,
+    pub chain_id: u64,
+    pub payload: Bytes,
+}
+
+pub struct ChecksumArgs {
+    pub block_number: u64,
+    pub timestamp: u64,
+    pub log_index: u32,
+    pub chain_id: U256,
+    pub log_hash: FixedBytes<32>,
+}
+
+pub struct Access {
+    pub block_number: u64,
+    pub timestamp: u64,
+    pub log_index: u32,
+    pub chain_id: U256,
+    pub checksum: FixedBytes<32>,
+}
+
+pub struct AdminAPI {}
+
+sol! {
+    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol#L6-L12
+    struct Identifier {
+        address origin;      // Account (contract) that emits the log
+        uint256 blocknumber; // Block number in which the log was emitted
+        uint256 logIndex;    // Index of the log in the array of all logs emitted in the block
+        uint256 timestamp;   // Timestamp that the log was emitted
+        uint256 chainId;     // Chain ID of the chain that emitted the log
+    }
+
+    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L203-L206
+    function relayMessage(
+        Identifier calldata _id,
+        bytes calldata _sentMessage,
+    ) external payable returns (bytes memory);
+}
+
+impl AdminAPI {
+    pub async fn get_access_list_for_identifier(
+        identifier: &IdentifierWithPayload,
+    ) -> Result<AccessList, Box<dyn std::error::Error>> {
+        if identifier.origin == Address::ZERO {
+            return Err("Origin address cannot be zero".into());
+        }
+
+        let access = identifier
+            .checksum_args(keccak256(identifier.payload.to_owned()))
+            .access();
+        let access_list: AccessList = vec![AccessListItem {
+            address: contracts::CROSS_L2_INBOX.to_owned(),
+            storage_keys: encode_access_list(&[access]),
+        }]
+        .into();
+
+        Ok(access_list)
+    }
+}
+
+impl IdentifierWithPayload {
+    pub fn new(log: &Log, timestamp: u64, chain_id: u64, payload: Bytes) -> Self {
+        Self {
+            origin: log.address(),
+            block_number: log.block_number.unwrap_or_default(),
+            log_index: log.log_index.unwrap_or_default(),
+            timestamp,
+            chain_id,
+            payload,
+        }
+    }
+
+    pub fn to_sol(&self) -> Identifier {
+        Identifier {
+            origin: self.origin,
+            blocknumber: U256::from(self.block_number),
+            logIndex: U256::from(self.log_index),
+            timestamp: U256::from(self.timestamp),
+            chainId: U256::from(self.chain_id),
+        }
+    }
+
+    pub fn checksum_args(&self, msg_hash: FixedBytes<32>) -> ChecksumArgs {
+        ChecksumArgs {
+            block_number: self.block_number,
+            timestamp: self.timestamp,
+            log_index: self.log_index as u32,
+            chain_id: U256::from(self.chain_id),
+            log_hash: payload_hash_to_log_hash(msg_hash, self.origin),
+        }
+    }
+}
+
+impl Access {
+    pub fn lookup_entry(&self) -> FixedBytes<32> {
+        println!("calculating lookup entry");
+        const PREFIX_LOOKUP: u8 = 0x01;
+
+        let mut out = [0u8; 32];
+        out[0] = PREFIX_LOOKUP;
+
+        // Write chain_id (as u64) at offset 4, since we've already used index 0 and leave indexes 1-3 as zero.
+        out[4..12].copy_from_slice(&self.chain_id.to_be_bytes::<32>()[..8]);
+
+        // Write block_number at offset 12.
+        out[12..20].copy_from_slice(&U256::from(self.block_number).to_be_bytes::<32>()[..8]);
+
+        // Write timestamp at offset 20.
+        out[20..28].copy_from_slice(&U256::from(self.timestamp).to_be_bytes::<32>()[..8]);
+
+        // Write log_index at offset 28.
+        out[28..32].copy_from_slice(&U256::from(self.log_index).to_be_bytes::<32>()[..4]);
+
+        FixedBytes::from(out)
+    }
+
+    pub fn chain_id_extension_entry(&self) -> FixedBytes<32> {
+        println!("calculating chain_id extension entry");
+        const PREFIX_CHAIN_ID_EXTENSION: u8 = 0x02;
+        let mut out = [0u8; 32];
+        out[0] = PREFIX_CHAIN_ID_EXTENSION;
+        let chain_id_bytes = &self.chain_id.to_be_bytes::<32>()[..24];
+        out[8..32].copy_from_slice(chain_id_bytes);
+        FixedBytes::from(out)
+    }
+}
+
+impl ChecksumArgs {
+    pub fn access(&self) -> Access {
+        Access {
+            block_number: self.block_number,
+            timestamp: self.timestamp,
+            log_index: self.log_index,
+            chain_id: self.chain_id,
+            checksum: self.checksum(),
+        }
+    }
+
+    pub fn checksum(&self) -> FixedBytes<32> {
+        println!("calculating checksum");
+        let mut id_packed = Vec::with_capacity(32); // 12 zero bytes + u64 + u64 + u32
+        id_packed.extend_from_slice(&[0u8; 12]);
+        id_packed.extend_from_slice(&self.block_number.to_be_bytes());
+        id_packed.extend_from_slice(&self.timestamp.to_be_bytes());
+        id_packed.extend_from_slice(&self.log_index.to_be_bytes());
+        let id_log_hash = keccak256([self.log_hash.as_slice(), id_packed.as_slice()].concat());
+        let chain_id_bytes = self.chain_id.to_be_bytes::<32>();
+        let mut out = keccak256([id_log_hash.as_slice(), &chain_id_bytes].concat());
+        out[0] = 0x03; // type/version byte
+        out
+    }
+}
+
+pub fn encode_access_list(accesses: &[Access]) -> Vec<FixedBytes<32>> {
+    let mut out = Vec::with_capacity(accesses.len() * 2);
+    for acc in accesses {
+        out.push(acc.lookup_entry());
+        if acc.chain_id <= U256::from(u64::MAX) {
+            out.push(acc.chain_id_extension_entry());
+        }
+        if acc.checksum.as_slice()[0] != 0x03 {
+            panic!("invalid checksum entry");
+        }
+        out.push(acc.checksum);
+    }
+    out
+}
+
+fn payload_hash_to_log_hash(payload_hash: FixedBytes<32>, origin: Address) -> FixedBytes<32> {
+    let mut msg = Vec::with_capacity(64); // 20 bytes for address (padded to 32) + 32 bytes for hash
+    msg.extend_from_slice(origin.as_slice());
+    msg.extend_from_slice(payload_hash.as_slice());
+    keccak256(&msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use contender_core::alloy::primitives::U256;
+
+    use crate::admin_api::{Access, ChecksumArgs, encode_access_list};
+
+    use super::*;
+
+    #[test]
+    fn test_checksum_args() {
+        let args = ChecksumArgs {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            log_hash: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let access = args.access();
+        assert_eq!(access.block_number, 123456);
+        assert_eq!(access.timestamp, 1622547800);
+        assert_eq!(access.log_index, 42);
+        assert_eq!(access.chain_id, U256::from(1));
+    }
+
+    #[test]
+    fn test_lookup_entry() {
+        let access = Access {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            checksum: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let entry = access.lookup_entry();
+        assert_eq!(entry.as_slice()[0], 0x01); // Check prefix
+        assert_eq!(
+            &entry.as_slice()[4..12],
+            &U256::from(1).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[12..20],
+            &U256::from(123456).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[20..28],
+            &U256::from(1622547800).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[28..32],
+            &U256::from(42).to_be_bytes::<32>()[..4]
+        );
+    }
+
+    #[test]
+    fn test_encode_access_list() {
+        let checksum_args = ChecksumArgs {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            log_hash: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let access = Access {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            checksum: checksum_args.checksum(),
+        };
+        let accesses = vec![access];
+        let encoded = encode_access_list(&accesses);
+        assert_eq!(encoded.len(), 3); // 1 lookup entry + 1 chain_id extension + 1 checksum
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,8 +6,6 @@ pub struct SpamArgs {
     pub sender: PrivateKeySigner,
     pub source_url: Url,
     pub destination_url: Url,
-    /// TODO: remove this; calculate access list locally
-    pub supersim_admin_url: Url,
     pub txs_per_batch: u64,
     pub duration: u64,
     pub make_report: bool,
@@ -33,12 +31,6 @@ impl SpamArgs {
         ))
         .expect("Invalid destination URL format");
 
-        let supersim_admin_url = Url::from_str(&read_var(
-            "OP_ADMIN_URL",
-            "http://localhost:8420".to_string(),
-        ))
-        .expect("Invalid Supersim admin URL format");
-
         let txs_per_batch = read_var("SPAM_TXS_PER_BATCH", 25);
         let duration = read_var("SPAM_DURATION", 5);
         let make_report = read_var("SPAM_MAKE_REPORT", false);
@@ -47,7 +39,6 @@ impl SpamArgs {
             sender,
             source_url,
             destination_url,
-            supersim_admin_url,
             txs_per_batch,
             duration,
             make_report,

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use contender_core::alloy::primitives::Address;
+use contender_core::alloy::{primitives::Address, sol};
 
 pub static L2_TO_L2_CROSS_DOMAIN_MESSENGER: LazyLock<Address> = LazyLock::new(|| {
     "0x4200000000000000000000000000000000000023"
@@ -13,6 +13,23 @@ pub static CROSS_L2_INBOX: LazyLock<Address> = LazyLock::new(|| {
         .parse::<Address>()
         .expect("Invalid address")
 });
+
+sol! {
+    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol#L6-L12
+    struct Identifier {
+        address origin;      // Account (contract) that emits the log
+        uint256 blocknumber; // Block number in which the log was emitted
+        uint256 logIndex;    // Index of the log in the array of all logs emitted in the block
+        uint256 timestamp;   // Timestamp that the log was emitted
+        uint256 chainId;     // Chain ID of the chain that emitted the log
+    }
+
+    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L203-L206
+    function relayMessage(
+        Identifier calldata _id,
+        bytes calldata _sentMessage,
+    ) external payable returns (bytes memory);
+}
 
 pub mod bytecode {
     use std::{str::FromStr, sync::LazyLock};

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -8,6 +8,12 @@ pub static L2_TO_L2_CROSS_DOMAIN_MESSENGER: LazyLock<Address> = LazyLock::new(||
         .expect("Invalid address")
 });
 
+pub static CROSS_L2_INBOX: LazyLock<Address> = LazyLock::new(|| {
+    "0x4200000000000000000000000000000000000022"
+        .parse::<Address>()
+        .expect("Invalid address")
+});
+
 pub mod bytecode {
     use std::{str::FromStr, sync::LazyLock};
 

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -9,6 +9,16 @@ pub static L2_TO_L2_CROSS_DOMAIN_MESSENGER: LazyLock<Address> = LazyLock::new(||
 });
 
 pub mod bytecode {
-    pub static BULLETIN_BOARD: &str = include_str!("./CrossChainBulletinBoard.hex");
-    pub static CREATE2_FACTORY: &str = include_str!("./Create2Factory.hex");
+    use std::{str::FromStr, sync::LazyLock};
+
+    use contender_core::alloy::primitives::Bytes;
+
+    pub static BULLETIN_BOARD: LazyLock<Bytes> = LazyLock::new(|| {
+        Bytes::from_str(include_str!("./CrossChainBulletinBoard.hex"))
+            .expect("failed to parse CrossChainBulletinBoard bytecode")
+    });
+    pub static CREATE2_FACTORY: LazyLock<Bytes> = LazyLock::new(|| {
+        Bytes::from_str(include_str!("./Create2Factory.hex"))
+            .expect("failed to parse Create2Factory bytecode")
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod admin_api;
 mod args;
 mod contracts;
 mod file_seed;
@@ -50,7 +51,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sender,
         source_url,
         destination_url,
-        supersim_admin_url,
         txs_per_batch,
         duration,
         make_report,
@@ -134,8 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         PrometheusCollector::default(),
     )
     .await?;
-    let callback =
-        OpInteropCallback::new(&source_url, &destination_url, &supersim_admin_url, None).await;
+    let callback = OpInteropCallback::new(&source_url, &destination_url, None).await;
 
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/src/op_relay.rs
+++ b/src/op_relay.rs
@@ -1,6 +1,6 @@
 use crate::{
-    admin_api::{AdminAPI, IdentifierWithPayload, relayMessageCall},
-    contracts::L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+    admin_api::{IdentifierWithPayload, get_access_list_for_identifier},
+    contracts::{L2_TO_L2_CROSS_DOMAIN_MESSENGER, relayMessageCall},
 };
 use contender_core::alloy::{
     hex::FromHex,
@@ -28,7 +28,7 @@ pub async fn relay_message(
 
     let id_req =
         IdentifierWithPayload::new(log, source_timestamp, source_chain_id, payload.to_owned());
-    let access_list = AdminAPI::get_access_list_for_identifier(&id_req).await?;
+    let access_list = get_access_list_for_identifier(&id_req).await?;
 
     let calldata = relayMessageCall {
         _id: id_req.to_sol(),

--- a/src/op_relay.rs
+++ b/src/op_relay.rs
@@ -1,253 +1,34 @@
-use crate::contracts::{self, L2_TO_L2_CROSS_DOMAIN_MESSENGER};
+use crate::{
+    admin_api::{AdminAPI, IdentifierWithPayload, relayMessageCall},
+    contracts::L2_TO_L2_CROSS_DOMAIN_MESSENGER,
+};
 use contender_core::alloy::{
-    hex::{FromHex, ToHexExt},
-    network::{AnyNetwork, AnyTransactionReceipt},
-    primitives::{Address, Bytes, FixedBytes, U256, keccak256},
-    providers::{DynProvider, PendingTransactionConfig, Provider, ProviderBuilder},
-    rpc::types::{AccessList, AccessListItem, Log, TransactionRequest},
-    sol,
+    hex::FromHex,
+    network::AnyTransactionReceipt,
+    primitives::{Bytes, FixedBytes},
+    providers::{PendingTransactionConfig, Provider},
+    rpc::types::{Log, TransactionRequest},
     sol_types::SolCall,
-    transports::http::reqwest::Url,
 };
 use contender_core::generator::types::AnyProvider;
-use serde::{Deserialize, Serialize};
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 pub static XCHAIN_LOG_TOPIC: LazyLock<FixedBytes<32>> = LazyLock::new(|| {
     FixedBytes::<32>::from_hex("0x382409ac69001e11931a28435afef442cbfd20d9891907e8fa373ba7d351f320")
         .expect("invalid topic")
 });
 
-sol! {
-    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol#L6-L12
-    struct Identifier {
-        address origin;      // Account (contract) that emits the log
-        uint256 blocknumber; // Block number in which the log was emitted
-        uint256 logIndex;    // Index of the log in the array of all logs emitted in the block
-        uint256 timestamp;   // Timestamp that the log was emitted
-        uint256 chainId;     // Chain ID of the chain that emitted the log
-    }
-
-    /// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L203-L206
-    function relayMessage(
-        Identifier calldata _id,
-        bytes calldata _sentMessage,
-    ) external payable returns (bytes memory);
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IdentifierWithPayload {
-    origin: Address,
-    block_number: u64,
-    log_index: u64,
-    timestamp: u64,
-    chain_id: u64,
-    payload: Bytes,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AccessListResponse {
-    pub access_list: AccessList,
-}
-
-pub struct ChecksumArgs {
-    block_number: u64,
-    timestamp: u64,
-    log_index: u32,
-    chain_id: U256,
-    log_hash: FixedBytes<32>,
-}
-
-pub struct Access {
-    pub block_number: u64,
-    pub timestamp: u64,
-    pub log_index: u32,
-    pub chain_id: U256,
-    pub checksum: FixedBytes<32>,
-}
-
-impl Access {
-    fn lookup_entry(&self) -> FixedBytes<32> {
-        println!("calculating lookup entry");
-        const PREFIX_LOOKUP: u8 = 0x01;
-
-        let mut out = [0u8; 32];
-        out[0] = PREFIX_LOOKUP;
-
-        // Write chain_id (as u64) at offset 4, since we've already used index 0 and leave indexes 1-3 as zero.
-        out[4..12].copy_from_slice(&self.chain_id.to_be_bytes::<32>()[..8]);
-
-        // Write block_number at offset 12.
-        out[12..20].copy_from_slice(&U256::from(self.block_number).to_be_bytes::<32>()[..8]);
-
-        // Write timestamp at offset 20.
-        out[20..28].copy_from_slice(&U256::from(self.timestamp).to_be_bytes::<32>()[..8]);
-
-        // Write log_index at offset 28.
-        out[28..32].copy_from_slice(&U256::from(self.log_index).to_be_bytes::<32>()[..4]);
-
-        FixedBytes::from(out)
-    }
-
-    fn chain_id_extension_entry(&self) -> FixedBytes<32> {
-        println!("calculating chain_id extension entry");
-        const PREFIX_CHAIN_ID_EXTENSION: u8 = 0x02;
-        let mut out = [0u8; 32];
-        out[0] = PREFIX_CHAIN_ID_EXTENSION;
-        let chain_id_bytes = &self.chain_id.to_be_bytes::<32>()[..24];
-        out[8..32].copy_from_slice(chain_id_bytes);
-        FixedBytes::from(out)
-    }
-}
-
-impl ChecksumArgs {
-    pub fn access(&self) -> Access {
-        Access {
-            block_number: self.block_number,
-            timestamp: self.timestamp,
-            log_index: self.log_index,
-            chain_id: self.chain_id,
-            checksum: self.checksum(),
-        }
-    }
-
-    pub fn checksum(&self) -> FixedBytes<32> {
-        println!("calculating checksum");
-        let mut id_packed = Vec::with_capacity(32); // 12 zero bytes + u64 + u64 + u32
-        id_packed.extend_from_slice(&[0u8; 12]);
-        id_packed.extend_from_slice(&self.block_number.to_be_bytes());
-        id_packed.extend_from_slice(&self.timestamp.to_be_bytes());
-        id_packed.extend_from_slice(&self.log_index.to_be_bytes());
-        let id_log_hash = keccak256([self.log_hash.as_slice(), id_packed.as_slice()].concat());
-        let chain_id_bytes = self.chain_id.to_be_bytes::<32>();
-        let mut out = keccak256([id_log_hash.as_slice(), &chain_id_bytes].concat());
-        out[0] = 0x03; // type/version byte
-        out
-    }
-}
-
-impl IdentifierWithPayload {
-    pub fn new(log: &Log, timestamp: u64, chain_id: u64, payload: Bytes) -> Self {
-        Self {
-            origin: log.address(),
-            block_number: log.block_number.unwrap_or_default(),
-            log_index: log.log_index.unwrap_or_default(),
-            timestamp,
-            chain_id,
-            payload,
-        }
-    }
-
-    pub fn to_sol(&self) -> Identifier {
-        Identifier {
-            origin: self.origin,
-            blocknumber: U256::from(self.block_number),
-            logIndex: U256::from(self.log_index),
-            timestamp: U256::from(self.timestamp),
-            chainId: U256::from(self.chain_id),
-        }
-    }
-
-    pub fn checksum_args(&self, msg_hash: FixedBytes<32>) -> ChecksumArgs {
-        ChecksumArgs {
-            block_number: self.block_number,
-            timestamp: self.timestamp,
-            log_index: self.log_index as u32,
-            chain_id: U256::from(self.chain_id),
-            log_hash: payload_hash_to_log_hash(msg_hash, self.origin),
-        }
-    }
-}
-
-fn payload_hash_to_log_hash(payload_hash: FixedBytes<32>, origin: Address) -> FixedBytes<32> {
-    let mut msg = Vec::with_capacity(64); // 20 bytes for address (padded to 32) + 32 bytes for hash
-    msg.extend_from_slice(origin.as_slice());
-    msg.extend_from_slice(payload_hash.as_slice());
-    keccak256(&msg)
-}
-
-pub struct SupersimAdminProvider {
-    provider: Arc<AnyProvider>,
-}
-
-impl SupersimAdminProvider {
-    pub fn new(url: Url) -> Self {
-        let provider = DynProvider::new(
-            ProviderBuilder::new()
-                .network::<AnyNetwork>()
-                .connect_http(url.to_owned()),
-        );
-        Self {
-            provider: Arc::new(provider),
-        }
-    }
-
-    pub async fn get_access_list_for_identifier(
-        &self,
-        identifier: &IdentifierWithPayload,
-    ) -> Result<AccessListResponse, Box<dyn std::error::Error>> {
-        get_access_list_for_identifier(identifier)
-            .map(|access_list| AccessListResponse { access_list })
-    }
-}
-
-fn encode_access_list(accesses: &[Access]) -> Vec<FixedBytes<32>> {
-    let mut out = Vec::with_capacity(accesses.len() * 2);
-    for acc in accesses {
-        out.push(acc.lookup_entry());
-        if acc.chain_id <= U256::from(u64::MAX) {
-            out.push(acc.chain_id_extension_entry());
-        }
-        println!("checksum: {}", acc.checksum.encode_hex());
-        if acc.checksum.as_slice()[0] != 0x03 {
-            panic!("invalid checksum entry");
-        }
-        out.push(acc.checksum);
-    }
-    out
-}
-
-fn get_access_list_for_identifier(
-    identifier: &IdentifierWithPayload,
-) -> Result<AccessList, Box<dyn std::error::Error>> {
-    if identifier.origin == Address::ZERO {
-        return Err("Origin address cannot be zero".into());
-    }
-
-    let access = identifier
-        .checksum_args(keccak256(identifier.payload.to_owned()))
-        .access();
-    let access_list: AccessList = vec![AccessListItem {
-        address: contracts::CROSS_L2_INBOX.to_owned(),
-        storage_keys: encode_access_list(&[access]),
-    }]
-    .into();
-
-    Ok(access_list)
-}
-
-pub fn build_payload(log: &Log) -> Bytes {
-    let mut payload = log.topics().concat();
-    payload.extend_from_slice(&log.data().data);
-    payload.into()
-}
-
 pub async fn relay_message(
     log: &Log,
     source_timestamp: u64,
     source_chain_id: u64,
     dest_provider: &AnyProvider,
-    op_admin_provider: &SupersimAdminProvider,
 ) -> Result<Option<PendingTransactionConfig>, Box<dyn std::error::Error>> {
     let payload = build_payload(log);
 
     let id_req =
         IdentifierWithPayload::new(log, source_timestamp, source_chain_id, payload.to_owned());
-    let access_list = op_admin_provider
-        .get_access_list_for_identifier(&id_req)
-        .await?;
+    let access_list = AdminAPI::get_access_list_for_identifier(&id_req).await?;
 
     let calldata = relayMessageCall {
         _id: id_req.to_sol(),
@@ -258,7 +39,7 @@ pub async fn relay_message(
     let tx_req = TransactionRequest::default()
         .to(*L2_TO_L2_CROSS_DOMAIN_MESSENGER)
         .input(calldata.into())
-        .access_list(access_list.access_list);
+        .access_list(access_list);
 
     let pending_tx = dest_provider
         .send_transaction(tx_req.into())
@@ -286,74 +67,8 @@ pub async fn find_xchain_log(
     Ok(log)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use contender_core::alloy::primitives::Bytes;
-
-    #[test]
-    fn test_checksum_args() {
-        let args = ChecksumArgs {
-            block_number: 123456,
-            timestamp: 1622547800,
-            log_index: 42,
-            chain_id: U256::from(1),
-            log_hash: FixedBytes::<32>::from([0u8; 32]),
-        };
-        let access = args.access();
-        assert_eq!(access.block_number, 123456);
-        assert_eq!(access.timestamp, 1622547800);
-        assert_eq!(access.log_index, 42);
-        assert_eq!(access.chain_id, U256::from(1));
-    }
-
-    #[test]
-    fn test_lookup_entry() {
-        let access = Access {
-            block_number: 123456,
-            timestamp: 1622547800,
-            log_index: 42,
-            chain_id: U256::from(1),
-            checksum: FixedBytes::<32>::from([0u8; 32]),
-        };
-        let entry = access.lookup_entry();
-        assert_eq!(entry.as_slice()[0], 0x01); // Check prefix
-        assert_eq!(
-            &entry.as_slice()[4..12],
-            &U256::from(1).to_be_bytes::<32>()[..8]
-        );
-        assert_eq!(
-            &entry.as_slice()[12..20],
-            &U256::from(123456).to_be_bytes::<32>()[..8]
-        );
-        assert_eq!(
-            &entry.as_slice()[20..28],
-            &U256::from(1622547800).to_be_bytes::<32>()[..8]
-        );
-        assert_eq!(
-            &entry.as_slice()[28..32],
-            &U256::from(42).to_be_bytes::<32>()[..4]
-        );
-    }
-
-    #[test]
-    fn test_encode_access_list() {
-        let checksum_args = ChecksumArgs {
-            block_number: 123456,
-            timestamp: 1622547800,
-            log_index: 42,
-            chain_id: U256::from(1),
-            log_hash: FixedBytes::<32>::from([0u8; 32]),
-        };
-        let access = Access {
-            block_number: 123456,
-            timestamp: 1622547800,
-            log_index: 42,
-            chain_id: U256::from(1),
-            checksum: checksum_args.checksum(),
-        };
-        let accesses = vec![access];
-        let encoded = encode_access_list(&accesses);
-        assert_eq!(encoded.len(), 3); // 1 lookup entry + 1 chain_id extension + 1 checksum
-    }
+pub fn build_payload(log: &Log) -> Bytes {
+    let mut payload = log.topics().concat();
+    payload.extend_from_slice(&log.data().data);
+    payload.into()
 }

--- a/src/op_relay.rs
+++ b/src/op_relay.rs
@@ -1,10 +1,10 @@
-use crate::contracts::L2_TO_L2_CROSS_DOMAIN_MESSENGER;
+use crate::contracts::{self, L2_TO_L2_CROSS_DOMAIN_MESSENGER};
 use contender_core::alloy::{
-    hex::FromHex,
+    hex::{FromHex, ToHexExt},
     network::{AnyNetwork, AnyTransactionReceipt},
-    primitives::{Address, Bytes, FixedBytes, U256},
+    primitives::{Address, Bytes, FixedBytes, U256, keccak256},
     providers::{DynProvider, PendingTransactionConfig, Provider, ProviderBuilder},
-    rpc::types::{AccessList, Log, TransactionRequest},
+    rpc::types::{AccessList, AccessListItem, Log, TransactionRequest},
     sol,
     sol_types::SolCall,
     transports::http::reqwest::Url,
@@ -52,6 +52,82 @@ pub struct AccessListResponse {
     pub access_list: AccessList,
 }
 
+pub struct ChecksumArgs {
+    block_number: u64,
+    timestamp: u64,
+    log_index: u32,
+    chain_id: U256,
+    log_hash: FixedBytes<32>,
+}
+
+pub struct Access {
+    pub block_number: u64,
+    pub timestamp: u64,
+    pub log_index: u32,
+    pub chain_id: U256,
+    pub checksum: FixedBytes<32>,
+}
+
+impl Access {
+    fn lookup_entry(&self) -> FixedBytes<32> {
+        println!("calculating lookup entry");
+        const PREFIX_LOOKUP: u8 = 0x01;
+
+        let mut out = [0u8; 32];
+        out[0] = PREFIX_LOOKUP;
+
+        // Write chain_id (as u64) at offset 4, since we've already used index 0 and leave indexes 1-3 as zero.
+        out[4..12].copy_from_slice(&self.chain_id.to_be_bytes::<32>()[..8]);
+
+        // Write block_number at offset 12.
+        out[12..20].copy_from_slice(&U256::from(self.block_number).to_be_bytes::<32>()[..8]);
+
+        // Write timestamp at offset 20.
+        out[20..28].copy_from_slice(&U256::from(self.timestamp).to_be_bytes::<32>()[..8]);
+
+        // Write log_index at offset 28.
+        out[28..32].copy_from_slice(&U256::from(self.log_index).to_be_bytes::<32>()[..4]);
+
+        FixedBytes::from(out)
+    }
+
+    fn chain_id_extension_entry(&self) -> FixedBytes<32> {
+        println!("calculating chain_id extension entry");
+        const PREFIX_CHAIN_ID_EXTENSION: u8 = 0x02;
+        let mut out = [0u8; 32];
+        out[0] = PREFIX_CHAIN_ID_EXTENSION;
+        let chain_id_bytes = &self.chain_id.to_be_bytes::<32>()[..24];
+        out[8..32].copy_from_slice(chain_id_bytes);
+        FixedBytes::from(out)
+    }
+}
+
+impl ChecksumArgs {
+    pub fn access(&self) -> Access {
+        Access {
+            block_number: self.block_number,
+            timestamp: self.timestamp,
+            log_index: self.log_index,
+            chain_id: self.chain_id,
+            checksum: self.checksum(),
+        }
+    }
+
+    pub fn checksum(&self) -> FixedBytes<32> {
+        println!("calculating checksum");
+        let mut id_packed = Vec::with_capacity(32); // 12 zero bytes + u64 + u64 + u32
+        id_packed.extend_from_slice(&[0u8; 12]);
+        id_packed.extend_from_slice(&self.block_number.to_be_bytes());
+        id_packed.extend_from_slice(&self.timestamp.to_be_bytes());
+        id_packed.extend_from_slice(&self.log_index.to_be_bytes());
+        let id_log_hash = keccak256([self.log_hash.as_slice(), id_packed.as_slice()].concat());
+        let chain_id_bytes = self.chain_id.to_be_bytes::<32>();
+        let mut out = keccak256([id_log_hash.as_slice(), &chain_id_bytes].concat());
+        out[0] = 0x03; // type/version byte
+        out
+    }
+}
+
 impl IdentifierWithPayload {
     pub fn new(log: &Log, timestamp: u64, chain_id: u64, payload: Bytes) -> Self {
         Self {
@@ -73,6 +149,23 @@ impl IdentifierWithPayload {
             chainId: U256::from(self.chain_id),
         }
     }
+
+    pub fn checksum_args(&self, msg_hash: FixedBytes<32>) -> ChecksumArgs {
+        ChecksumArgs {
+            block_number: self.block_number,
+            timestamp: self.timestamp,
+            log_index: self.log_index as u32,
+            chain_id: U256::from(self.chain_id),
+            log_hash: payload_hash_to_log_hash(msg_hash, self.origin),
+        }
+    }
+}
+
+fn payload_hash_to_log_hash(payload_hash: FixedBytes<32>, origin: Address) -> FixedBytes<32> {
+    let mut msg = Vec::with_capacity(64); // 20 bytes for address (padded to 32) + 32 bytes for hash
+    msg.extend_from_slice(origin.as_slice());
+    msg.extend_from_slice(payload_hash.as_slice());
+    keccak256(&msg)
 }
 
 pub struct SupersimAdminProvider {
@@ -95,14 +188,44 @@ impl SupersimAdminProvider {
         &self,
         identifier: &IdentifierWithPayload,
     ) -> Result<AccessListResponse, Box<dyn std::error::Error>> {
-        self.provider
-            .raw_request::<[IdentifierWithPayload; 1], AccessListResponse>(
-                "admin_getAccessListForIdentifier".into(),
-                [identifier.to_owned()],
-            )
-            .await
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        get_access_list_for_identifier(identifier)
+            .map(|access_list| AccessListResponse { access_list })
     }
+}
+
+fn encode_access_list(accesses: &[Access]) -> Vec<FixedBytes<32>> {
+    let mut out = Vec::with_capacity(accesses.len() * 2);
+    for acc in accesses {
+        out.push(acc.lookup_entry());
+        if acc.chain_id <= U256::from(u64::MAX) {
+            out.push(acc.chain_id_extension_entry());
+        }
+        println!("checksum: {}", acc.checksum.encode_hex());
+        if acc.checksum.as_slice()[0] != 0x03 {
+            panic!("invalid checksum entry");
+        }
+        out.push(acc.checksum);
+    }
+    out
+}
+
+fn get_access_list_for_identifier(
+    identifier: &IdentifierWithPayload,
+) -> Result<AccessList, Box<dyn std::error::Error>> {
+    if identifier.origin == Address::ZERO {
+        return Err("Origin address cannot be zero".into());
+    }
+
+    let access = identifier
+        .checksum_args(keccak256(identifier.payload.to_owned()))
+        .access();
+    let access_list: AccessList = vec![AccessListItem {
+        address: contracts::CROSS_L2_INBOX.to_owned(),
+        storage_keys: encode_access_list(&[access]),
+    }]
+    .into();
+
+    Ok(access_list)
 }
 
 pub fn build_payload(log: &Log) -> Bytes {
@@ -161,4 +284,76 @@ pub async fn find_xchain_log(
         .cloned();
 
     Ok(log)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use contender_core::alloy::primitives::Bytes;
+
+    #[test]
+    fn test_checksum_args() {
+        let args = ChecksumArgs {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            log_hash: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let access = args.access();
+        assert_eq!(access.block_number, 123456);
+        assert_eq!(access.timestamp, 1622547800);
+        assert_eq!(access.log_index, 42);
+        assert_eq!(access.chain_id, U256::from(1));
+    }
+
+    #[test]
+    fn test_lookup_entry() {
+        let access = Access {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            checksum: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let entry = access.lookup_entry();
+        assert_eq!(entry.as_slice()[0], 0x01); // Check prefix
+        assert_eq!(
+            &entry.as_slice()[4..12],
+            &U256::from(1).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[12..20],
+            &U256::from(123456).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[20..28],
+            &U256::from(1622547800).to_be_bytes::<32>()[..8]
+        );
+        assert_eq!(
+            &entry.as_slice()[28..32],
+            &U256::from(42).to_be_bytes::<32>()[..4]
+        );
+    }
+
+    #[test]
+    fn test_encode_access_list() {
+        let checksum_args = ChecksumArgs {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            log_hash: FixedBytes::<32>::from([0u8; 32]),
+        };
+        let access = Access {
+            block_number: 123456,
+            timestamp: 1622547800,
+            log_index: 42,
+            chain_id: U256::from(1),
+            checksum: checksum_args.checksum(),
+        };
+        let accesses = vec![access];
+        let encoded = encode_access_list(&accesses);
+        assert_eq!(encoded.len(), 3); // 1 lookup entry + 1 chain_id extension + 1 checksum
+    }
 }

--- a/src/spam_callback.rs
+++ b/src/spam_callback.rs
@@ -1,4 +1,4 @@
-use crate::op_relay::{SupersimAdminProvider, find_xchain_log, relay_message};
+use crate::op_relay::{find_xchain_log, relay_message};
 use contender_core::alloy::{
     network::EthereumWallet,
     primitives::TxHash,
@@ -25,7 +25,6 @@ pub static OP_ACTOR_NAME: &str = "op-dest";
 pub struct OpInteropCallback {
     destination_provider: Arc<AnyProvider>,
     source_provider: Arc<AnyProvider>,
-    op_admin_provider: Arc<SupersimAdminProvider>,
     source_chain_id: u64,
 }
 
@@ -33,7 +32,6 @@ impl OpInteropCallback {
     pub async fn new(
         source_rpc_url: &Url,
         destination_rpc_url: &Url,
-        admin_url: &Url,
         admin_signer: Option<&PrivateKeySigner>,
     ) -> Self {
         let source_provider = DynProvider::new(
@@ -60,11 +58,9 @@ impl OpInteropCallback {
                 .wallet(destination_wallet)
                 .connect_http(destination_rpc_url.to_owned()),
         );
-        let op_admin_provider = SupersimAdminProvider::new(admin_url.to_owned());
         Self {
             destination_provider: Arc::new(destination_provider),
             source_provider: Arc::new(source_provider),
-            op_admin_provider: Arc::new(op_admin_provider),
             source_chain_id,
         }
     }
@@ -86,7 +82,6 @@ impl OnTxSent for OpInteropCallback {
     ) -> Option<tokio_task::JoinHandle<()>> {
         let dest_provider = self.destination_provider.clone();
         let source_provider = self.source_provider.clone();
-        let op_admin_provider = self.op_admin_provider.clone();
         let source_chain_id = self.source_chain_id;
         let source_tx_hash = pending_tx.tx_hash().to_owned();
 
@@ -96,7 +91,6 @@ impl OnTxSent for OpInteropCallback {
                 source_tx_hash,
                 source_chain_id,
                 &dest_provider,
-                &op_admin_provider,
             )
             .await
             .map_err(|e| format!("Failed to handle on_tx_sent: {e}"))
@@ -133,7 +127,6 @@ pub async fn handle_on_tx_sent(
     tx_hash: TxHash,
     source_chain_id: u64,
     destination_provider: &AnyProvider,
-    op_admin_provider: &SupersimAdminProvider,
 ) -> Result<Option<TxHash>, Box<dyn std::error::Error>> {
     // wait for tx to land
     let _ = source_provider
@@ -161,7 +154,6 @@ pub async fn handle_on_tx_sent(
             block.header.timestamp,
             source_chain_id,
             destination_provider,
-            op_admin_provider,
         )
         .await?;
         relay_tx_hash = res.map(|tx| tx.tx_hash().to_owned());

--- a/src/spam_callback.rs
+++ b/src/spam_callback.rs
@@ -45,15 +45,15 @@ impl OpInteropCallback {
             .get_chain_id()
             .await
             .expect("Failed to get source chain ID");
-        let destination_wallet = if let Some(signer) = admin_signer {
-            EthereumWallet::from(signer.to_owned())
-        } else {
-            PrivateKeySigner::from_str(
-                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        let destination_wallet: EthereumWallet = admin_signer
+            .unwrap_or(
+                &PrivateKeySigner::from_str(
+                    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+                )
+                .unwrap(),
             )
-            .unwrap()
-            .into()
-        };
+            .to_owned()
+            .into();
         let destination_provider = DynProvider::new(
             ProviderBuilder::new()
                 .network::<AnyNetwork>()


### PR DESCRIPTION
removes admin API dependence by implementing `admin_getAccessListForIdentifier` locally (previously a remote API method)