### PR TITLE
upgrade to new contender API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,8 +1980,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "serde",
@@ -1990,8 +1990,8 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2012,8 +2012,8 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2037,8 +2037,8 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "chrono",
@@ -2056,8 +2056,8 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2069,8 +2069,8 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.4.2"
-source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
+version = "0.4.3"
+source = "git+https://github.com/flashbots/contender#b1ae8fe9c3a61ea3a3f51bc7d9b0d40b4eae82ef"
 dependencies = [
  "alloy",
  "contender_core",
@@ -5053,7 +5053,6 @@ name = "op-interop-contender"
 version = "0.1.0"
 dependencies = [
  "contender_core",
- "contender_engine_provider",
  "contender_report",
  "contender_sqlite",
  "contender_testfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,8 +1980,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "contender_bundle_provider"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "serde",
@@ -1990,8 +1990,8 @@ dependencies = [
 
 [[package]]
 name = "contender_core"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2012,8 +2012,8 @@ dependencies = [
 
 [[package]]
 name = "contender_engine_provider"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "alloy-json-rpc",
@@ -2037,8 +2037,8 @@ dependencies = [
 
 [[package]]
 name = "contender_report"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "chrono",
@@ -2056,8 +2056,8 @@ dependencies = [
 
 [[package]]
 name = "contender_sqlite"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "contender_core",
@@ -2069,8 +2069,8 @@ dependencies = [
 
 [[package]]
 name = "contender_testfile"
-version = "0.3.0"
-source = "git+https://github.com/flashbots/contender#e0b24770095e0c8b6fda2948e76a9e1a1aa3e2e5"
+version = "0.4.2"
+source = "git+https://github.com/flashbots/contender?rev=a54ee6451e97525ab8eee25963c28689ff03eac4#a54ee6451e97525ab8eee25963c28689ff03eac4"
 dependencies = [
  "alloy",
  "contender_core",
@@ -5053,6 +5053,7 @@ name = "op-interop-contender"
 version = "0.1.0"
 dependencies = [
  "contender_core",
+ "contender_engine_provider",
  "contender_report",
  "contender_sqlite",
  "contender_testfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-contender_core = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-contender_report = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-contender_sqlite = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-contender_testfile = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
+# contender_core = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
+# contender_report = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
+# contender_sqlite = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
+# contender_testfile = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
+contender_core = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+contender_report = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+contender_testfile = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+contender_engine_provider = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+contender_sqlite = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
 
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.40.0", features = ['rt-multi-thread'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,14 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# contender_core = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-# contender_report = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-# contender_sqlite = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-# contender_testfile = { git = "https://github.com/flashbots/contender", version = "0.3.0" }
-contender_core = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
-contender_report = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
-contender_testfile = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
-contender_engine_provider = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
-contender_sqlite = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+contender_core = { git = "https://github.com/flashbots/contender", version = "0.4.3" }
+contender_report = { git = "https://github.com/flashbots/contender", version = "0.4.3" }
+contender_sqlite = { git = "https://github.com/flashbots/contender", version = "0.4.3" }
+contender_testfile = { git = "https://github.com/flashbots/contender", version = "0.4.3" }
+# contender_core = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+# contender_report = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+# contender_testfile = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
+# contender_sqlite = { git = "https://github.com/flashbots/contender", rev = "a54ee6451e97525ab8eee25963c28689ff03eac4" }
 
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.40.0", features = ['rt-multi-thread'] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,12 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .connect_http(destination_url.to_owned()),
     ));
     let destination_chain_id = dest_client.get_chain_id().await?;
-
-    // how often we send txs
-    let interval = Duration::from_millis(500);
-
     let bulletin_addrs = deploy_bulletin_contracts(&sender, &source_url, &destination_url).await?;
-
     let config = bulletin_board::get_config(bulletin_addrs[0], destination_chain_id);
     let agents = config.build_agent_store(&seedfile, AgentSpec::default());
     let dest_tx_actor = Arc::new(TxActorHandle::new(120, db.clone(), dest_client.clone()));
@@ -83,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let scenario = ctx.build_scenario().await?;
 
     let mut contender = Contender::new(ctx);
-    let spammer = TimedSpammer::new(interval);
+    let spammer = TimedSpammer::new(Duration::from_millis(500));
     let callback = OpInteropCallback::new(&source_url, &destination_url, None).await;
 
     contender

--- a/src/scenarios/bulletin_board.rs
+++ b/src/scenarios/bulletin_board.rs
@@ -13,16 +13,12 @@ pub fn get_config(bulletin_board: Address, destination_chainid: u64) -> TestConf
         // so we have our own deployment code
         create: None,
         setup: None,
-        spam: Some(vec![SpamRequest::Tx(FunctionCallDefinition {
-            to: bulletin_board.to_string(),
-            from: None,
-            from_pool: Some("spammers".into()),
-            signature: Some("postBulletin(uint256 toChainId, bytes calldata data)".to_string()),
-            args: Some(vec![destination_chainid.to_string(), "howdy".encode_hex()]),
-            gas_limit: None,
-            value: None,
-            fuzz: None,
-            kind: None,
-        })]),
+        spam: Some(vec![SpamRequest::Tx(
+            FunctionCallDefinition::new(bulletin_board.to_string())
+                .with_from_pool("spammers")
+                .with_signature("postBulletin(uint256 toChainId, bytes calldata data)")
+                .with_args(&[destination_chainid.to_string(), "howdy".encode_hex()])
+                .into(),
+        )]),
     }
 }


### PR DESCRIPTION
this PR just simplifies things a bit.
new contender api reduces the amount of code we need to write, and I move that ugly manual contract-deployment step into its own function.

## TODO

- [x] wait until this is released in an official contender version, then use that version instead of the commit ref.